### PR TITLE
Problem on connectionString for PhotoSharingContext : must be a local database

### DIFF
--- a/Allfiles/20486C/Mod13/LabFiles/PhotoSharingApplication_13_begin/PhotoSharingApplication/Web.config
+++ b/Allfiles/20486C/Mod13/LabFiles/PhotoSharingApplication_13_begin/PhotoSharingApplication/Web.config
@@ -18,7 +18,7 @@
     <add key="MvcSiteMapProvider_ScanAssembliesForSiteMapNodes" value="true" />
   </appSettings>
   <connectionStrings>
-    <add name="PhotoSharingContext" connectionString="Server=tcp:moim.database.windows.net,1433;Initial Catalog=PhotoSharingDB;Persist Security Info=False;User ID={your_username};Password=Pa$$w0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;" providerName="System.Data.SqlClient" />
+    <add name="PhotoSharingContext" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\PhotoSharingData.mdf;Integrated Security=True" providerName="System.Data.SqlClient" />
     <add name="PhotoAppServices" connectionString="Server=tcp:moin2.database.windows.net,1433;Initial Catalog=PhotoAppServices;Persist Security Info=False;User ID={your_username};Password=Pa$$w0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;" providerName="System.Data.SqlClient" />    
   </connectionStrings>
   <!---->

--- a/Allfiles/20486C/Mod13/LabFiles/PhotoSharingApplication_13_end/PhotoSharingApplication/Web.config
+++ b/Allfiles/20486C/Mod13/LabFiles/PhotoSharingApplication_13_end/PhotoSharingApplication/Web.config
@@ -18,7 +18,7 @@
     <add key="MvcSiteMapProvider_ScanAssembliesForSiteMapNodes" value="true" />
   </appSettings>
   <connectionStrings>
-    <add name="PhotoSharingContext" connectionString="Server=tcp:moim.database.windows.net,1433;Initial Catalog=PhotoSharingDB;Persist Security Info=False;User ID={your_username};Password=Pa$$w0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;" providerName="System.Data.SqlClient" />
+    <add name="PhotoSharingContext" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\PhotoSharingData.mdf;Integrated Security=True" providerName="System.Data.SqlClient" />
     <add name="PhotoAppServices" connectionString="Server=tcp:moin2.database.windows.net,1433;Initial Catalog=PhotoAppServices;Persist Security Info=False;User ID={your_username};Password=Pa$$w0rd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;" providerName="System.Data.SqlClient" />    
   </connectionStrings>
   <!---->


### PR DESCRIPTION
Hi,

Connection string was not correct.
Must be a local database.

Regards,
Sybaris